### PR TITLE
allow searching for files recursively

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.clj-kondo
+.cpcache
+.lsp
+.nrepl-port

--- a/src/exoscale/deps_modules.clj
+++ b/src/exoscale/deps_modules.clj
@@ -17,17 +17,13 @@
    :input-deps-edn-file "deps.edn"
    :versions-edn-file ".deps-versions.edn"
    :versions-edn-keypath []
-   :modules-patterns ["modules/*/deps.edn"]})
-
-(defn- is-project-file?
-  [project-file-name path]
-  (= (p/filename path) (str project-file-name)))
+   :modules-deps-edn-patterns ["modules/*/deps.edn"]})
 
 (defn- find-modules-deps
-  [{:keys [modules-dir modules-patterns input-deps-edn-file]}]
+  [{:keys [modules-dir modules-deps-edn-patterns input-deps-edn-file]}]
   (->> (if (some? modules-dir)
          (p/list-modules-files modules-dir input-deps-edn-file)
-         (p/glob-modules-files "." modules-patterns))))
+         (p/glob-modules-files "." modules-deps-edn-patterns))))
 
 (defn- deps-edn-out-file
   [dot-deps-edn-file {:keys [output-deps-edn-file]}]

--- a/src/exoscale/deps_modules/path.clj
+++ b/src/exoscale/deps_modules/path.clj
@@ -1,0 +1,40 @@
+(ns exoscale.deps-modules.path
+  (:import (java.nio.file Path Paths Files FileVisitOption)))
+
+(defn ^Path build
+  [s & elements]
+  (if (instance? Path s)
+    s
+    (Paths/get (str s) (into-array String elements))))
+
+(defn ^Path parent
+  [p]
+  (.getParent (build p)))
+
+(defn ^Path sibling
+  [p1 p2]
+  (.resolveSibling (build p1) (build p2)))
+
+(defn canonicalize
+  "Resolve a file path relative to the file it was referenced in."
+  [module dst]
+  (str
+   (.relativize
+    (.getParent (build module))
+    (build dst))))
+
+(defn file?
+  [p]
+  (-> (build p) .toFile .isFile))
+
+(defn filename
+  [p]
+  (-> (build p) .toFile .getName))
+
+(defn find-files
+  [path max-depth pred]
+  (->> (Files/walk (build path) (int max-depth) (into-array FileVisitOption []))
+       (.iterator)
+       (iterator-seq)
+       (filter pred)
+       (into [] (map #(.toFile ^Path %)))))

--- a/src/exoscale/deps_modules/path.clj
+++ b/src/exoscale/deps_modules/path.clj
@@ -1,10 +1,18 @@
 (ns exoscale.deps-modules.path
-  (:import (java.nio.file Path Paths Files FileVisitOption)))
+  (:require [clojure.java.io :as io])
+  (:import (java.io File)
+           (java.nio.file Path Paths Files FileVisitOption FileSystems)))
 
 (defn ^Path build
   [s & elements]
-  (if (instance? Path s)
+  (cond
+    (instance? Path s)
     s
+
+    (instance? File s)
+    (.toPath s)
+
+    :else
     (Paths/get (str s) (into-array String elements))))
 
 (defn ^Path parent
@@ -17,7 +25,7 @@
 
 (defn canonicalize
   "Resolve a file path relative to the file it was referenced in."
-  [module dst]
+  [dst module]
   (str
    (.relativize
     (.getParent (build module))
@@ -31,10 +39,32 @@
   [p]
   (-> (build p) .toFile .getName))
 
-(defn find-files
-  [path max-depth pred]
-  (->> (Files/walk (build path) (int max-depth) (into-array FileVisitOption []))
+(defn list-modules-files
+  [path project-file-name]
+  (for [module-dir (.listFiles (io/file path))
+        :let [path (build (str module-dir) project-file-name)
+              file (.toFile path)]
+        :when (and (.exists file) (.isFile file))]
+    file))
+
+(defn build-matcher
+  [root-path patterns]
+  (->> (for [p patterns]
+         (let [glob (str "glob:" p)
+               matcher (-> (FileSystems/getDefault)
+                           (.getPathMatcher glob))]
+           (fn [test-path]
+             (when (.isFile (.toFile test-path))
+               (let [path (.relativize root-path test-path)]
+                 (.matches matcher path))))))
+       (apply some-fn)))
+
+(defn glob-modules-files
+  [root-path patterns]
+  (->> (Files/walk (build root-path) 100 (into-array FileVisitOption []))
        (.iterator)
        (iterator-seq)
-       (filter pred)
-       (into [] (map #(.toFile ^Path %)))))
+       (filter (build-matcher (build root-path) patterns))
+       (map #(.toFile %))))
+
+


### PR DESCRIPTION
A couple of things are handled in this PR:

- project files are searched for in a recursive manner, allowing to include both the project root and dependent modules in the search.
- references to undeclared managed dependencies raise exceptions
- a new `:exo.deps/inherit` value is introduced: `:canonicalize-local-root`; This value allows referencing to the same local-root in modules living across different hierarchies
