### PR TITLE
enforce output format

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.11.1"}
+        cljfmt/cljfmt {:mvn/version "0.8.2"}
         rewrite-clj/rewrite-clj {:mvn/version "1.0.699-alpha"}}
 
  :tools/usage

--- a/src/exoscale/deps_modules.clj
+++ b/src/exoscale/deps_modules.clj
@@ -16,7 +16,9 @@
    :versions-file "deps.edn"
    :aliases-keypath [:exoscale.deps/managed-aliases]
    :versions-keypath [:exoscale.deps/managed-dependencies]
-   :deps-files-keypath [:exoscale.deps/deps-files]})
+   :deps-files-keypath [:exoscale.deps/deps-files]
+   :cljfmt-options (assoc cljfmt/default-options
+                          :split-keypairs-over-multiple-lines? true)})
 
 (def default-deps-files
   ["deps.edn" "modules/*/deps.edn"])
@@ -114,10 +116,9 @@
         z/root-string)))
 
 (defn fmt
-  [s]
+  [s opts]
   (#'cljfmt/reformat-string ; we could vendor that eventually
-   (assoc cljfmt/default-options
-          :split-keypairs-over-multiple-lines? true)
+   opts
    s))
 
 (defn merge-deps
@@ -129,7 +130,8 @@
         deps-files (find-deps-files opts)]
     ;; for all .deps.edn run update-deps-versions
     (run! (fn [file]
-            (let [deps-out (fmt (update-deps-versions versions file))]
+            (let [deps-out (fmt (update-deps-versions versions file)
+                                opts)]
               (if dry-run?
                 (do
                   (println (apply str (repeat 80 "-")))
@@ -189,7 +191,8 @@
         deps-files (find-deps-files opts)]
     ;; for all .deps.edn run update-deps-versions
     (run! (fn [file]
-            (let [deps-out (fmt (update-aliases versions file))]
+            (let [deps-out (fmt (update-aliases versions file)
+                                opts)]
               (if dry-run?
                 (do
                   (println (apply str (repeat 80 "-")))

--- a/src/exoscale/deps_modules.clj
+++ b/src/exoscale/deps_modules.clj
@@ -1,9 +1,9 @@
 (ns exoscale.deps-modules
-  (:require [clojure.java.io :as io]
+  (:require [cljfmt.main :as cljfmt]
             [clojure.edn :as edn]
-            [rewrite-clj.zip :as z]
+            [clojure.spec.alpha :as s]
             [exoscale.deps-modules.path :as p]
-            [clojure.spec.alpha :as s]))
+            [rewrite-clj.zip :as z]))
 
 (s/def :exoscale.deps/inherit
   (s/or :exoscale.deps.inherit/all #{:all}
@@ -113,6 +113,13 @@
           zloc)
         z/root-string)))
 
+(defn fmt
+  [s]
+  (#'cljfmt/reformat-string ; we could vendor that eventually
+   (assoc cljfmt/default-options
+          :split-keypairs-over-multiple-lines? true)
+   s))
+
 (defn merge-deps
   "Entry point via tools.build \"tool\""
   [opts]
@@ -122,7 +129,7 @@
         deps-files (find-deps-files opts)]
     ;; for all .deps.edn run update-deps-versions
     (run! (fn [file]
-            (let [deps-out (update-deps-versions versions file)]
+            (let [deps-out (fmt (update-deps-versions versions file))]
               (if dry-run?
                 (do
                   (println (apply str (repeat 80 "-")))
@@ -182,7 +189,7 @@
         deps-files (find-deps-files opts)]
     ;; for all .deps.edn run update-deps-versions
     (run! (fn [file]
-            (let [deps-out (update-aliases versions file)]
+            (let [deps-out (fmt (update-aliases versions file))]
               (if dry-run?
                 (do
                   (println (apply str (repeat 80 "-")))

--- a/src/exoscale/deps_modules.clj
+++ b/src/exoscale/deps_modules.clj
@@ -117,9 +117,7 @@
 
 (defn fmt
   [s opts]
-  (#'cljfmt/reformat-string ; we could vendor that eventually
-   opts
-   s))
+  (#'cljfmt/reformat-string opts s))
 
 (defn merge-deps
   "Entry point via tools.build \"tool\""


### PR DESCRIPTION
It also ensures formatting is consistent, as coord maps are no longer a single line it makes things a bit more readable also and frees us from having to mess with zippers to get there, that is until we want to spend more time on this.
